### PR TITLE
fixed `match` key lookup from request json on `change-nickname` endpoint

### DIFF
--- a/routes/api/osu_api_routes.py
+++ b/routes/api/osu_api_routes.py
@@ -155,7 +155,7 @@ def remove_osu_user_from_match():
 @osu_api_blueprint.post('/osu/change-nickname')
 def change_nickname():
     user = request.json["user"]
-    match_id = request.json["match_id"]
+    match_id = request.json["match"]
     nickname = request.json["nickname"]
     if nickname == "":
         nickname = None


### PR DESCRIPTION
Mismatch from when I was refactoring the code causes the match lookup to be invalild